### PR TITLE
fix: use correct Gemini API key env variable

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -86,11 +86,13 @@ document.addEventListener('DOMContentLoaded', async (event) => {
   // The Google Maps API key is now managed within the map_app component.
   rootElement.appendChild(mapApp);
 
-  const geminiApiKey = process.env.API_KEY;
+  // Read the Gemini API key from the environment. The vite config exposes
+  // `GEMINI_API_KEY` to the client, so we reference that variable directly.
+  const geminiApiKey = process.env.GEMINI_API_KEY;
 
   if (!geminiApiKey) {
     const errorMessage = await marked.parse(
-      '**Configuration Error:** The Gemini API Key is missing. Please add `API_KEY=YOUR_KEY_HERE` to your `.env` file to enable the chat. You may need to restart the server after creating the file.',
+      '**Configuration Error:** The Gemini API Key is missing. Please add `GEMINI_API_KEY=YOUR_KEY_HERE` to your `.env` file to enable the chat. You may need to restart the server after creating the file.',
     );
     mapApp.addMessage('error', errorMessage);
     mapApp.setChatState(ChatState.IDLE); // Ensure UI is not locked

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,9 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+        // Expose the Gemini API key to the client via a single environment
+        // variable. This allows the frontend to reference
+        // `process.env.GEMINI_API_KEY` without confusion.
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },
       resolve: {


### PR DESCRIPTION
## Summary
- use `process.env.GEMINI_API_KEY` instead of `API_KEY`
- simplify Vite config to expose a single `GEMINI_API_KEY`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893e1f6764c832a84c6b202317215b7